### PR TITLE
cubemx changes instead of code

### DIFF
--- a/Core/Inc/stm32f4xx_it.h
+++ b/Core/Inc/stm32f4xx_it.h
@@ -53,6 +53,7 @@ void BusFault_Handler(void);
 void UsageFault_Handler(void);
 void DebugMon_Handler(void);
 void TIM1_UP_TIM10_IRQHandler(void);
+void TIM1_CC_IRQHandler(void);
 void TIM6_DAC_IRQHandler(void);
 void DMA2_Stream0_IRQHandler(void);
 void CAN2_RX0_IRQHandler(void);

--- a/Core/Src/tim.c
+++ b/Core/Src/tim.c
@@ -186,13 +186,15 @@ void HAL_TIM_IC_MspInit(TIM_HandleTypeDef* tim_icHandle)
     /* TIM1 interrupt Init */
     HAL_NVIC_SetPriority(TIM1_UP_TIM10_IRQn, 5, 0);
     HAL_NVIC_EnableIRQ(TIM1_UP_TIM10_IRQn);
-  /* USER CODE BEGIN TIM1_MspInit 1 */
-    /* Input capture fires on TIM1_CC_IRQn, not the update line. Without this
-     * the capture flags were only serviced incidentally by the 1 ms TIM10 tick
-     * sharing TIM1_UP_TIM10_IRQn, capping the count at one pulse per channel
-     * per millisecond and under-reporting wheel speed. */
     HAL_NVIC_SetPriority(TIM1_CC_IRQn, 5, 0);
     HAL_NVIC_EnableIRQ(TIM1_CC_IRQn);
+  /* USER CODE BEGIN TIM1_MspInit 1 */
+    /* NOTE: the TIM1_CC_IRQn enable above is generated from the .ioc and must
+     * stay enabled. Wheel speed input capture fires on the capture/compare
+     * line, not the update line. Without it the capture flags are only
+     * serviced incidentally by the 1 ms TIM10 tick sharing TIM1_UP_TIM10_IRQn,
+     * which caps the count at one pulse per channel per millisecond and
+     * under-reports wheel speed. Do not untick it in CubeMX. */
   /* USER CODE END TIM1_MspInit 1 */
   }
 }
@@ -262,6 +264,7 @@ void HAL_TIM_IC_MspDeInit(TIM_HandleTypeDef* tim_icHandle)
 
     /* TIM1 interrupt Deinit */
     HAL_NVIC_DisableIRQ(TIM1_UP_TIM10_IRQn);
+    HAL_NVIC_DisableIRQ(TIM1_CC_IRQn);
   /* USER CODE BEGIN TIM1_MspDeInit 1 */
 
   /* USER CODE END TIM1_MspDeInit 1 */

--- a/SCU2.0.ioc
+++ b/SCU2.0.ioc
@@ -158,6 +158,7 @@ NVIC.SavedPendsvIrqHandlerGenerated=true
 NVIC.SavedSvcallIrqHandlerGenerated=true
 NVIC.SavedSystickIrqHandlerGenerated=true
 NVIC.SysTick_IRQn=true\:15\:0\:false\:false\:false\:true\:true\:false\:false
+NVIC.TIM1_CC_IRQn=true\:5\:0\:false\:false\:true\:true\:true\:true\:true
 NVIC.TIM1_UP_TIM10_IRQn=true\:5\:0\:false\:false\:true\:false\:false\:true\:true
 NVIC.TIM6_DAC_IRQn=true\:5\:0\:false\:false\:true\:true\:true\:true\:true
 NVIC.TimeBase=TIM1_UP_TIM10_IRQn


### PR DESCRIPTION
previous scu fixes were coded but this meant that project generating through cubemx will revert some things. I just figured out what regenerating would reset, reversed and figured out how to do it the CubeMX way, then removed duplicate code.